### PR TITLE
Polish SpinningTop.

### DIFF
--- a/Assets/Scripts/SpinningTop/SpinningTopController.cs
+++ b/Assets/Scripts/SpinningTop/SpinningTopController.cs
@@ -71,11 +71,12 @@ public class SpinningTopController : MonoBehaviour
 
 	public void OnJump(InputAction.CallbackContext context)
 	{
-		if(!jumpSoundEmitter.IsPlaying()) jumpSoundEmitter.Play();
 		
 		if (context.started && isGrounded)
 		{
-			rb.AddForce(Vector3.up * jumpForce, ForceMode.Impulse);
+            if (!jumpSoundEmitter.IsPlaying()) jumpSoundEmitter.Play();
+
+            rb.AddForce(Vector3.up * jumpForce, ForceMode.Impulse);
 		}
 	}
 
@@ -110,13 +111,13 @@ public class SpinningTopController : MonoBehaviour
 		{
 			Vector2 desiredDir = m_moveInput.normalized;
 			Vector2 desiredVelocity = desiredDir * maxSpeed;
-			velocity = Vector2.Lerp(velocity, desiredVelocity, directionLerpSpeed * Time.deltaTime);
+			velocity = Vector2.Lerp(velocity, desiredVelocity, directionLerpSpeed * Time.fixedDeltaTime);
 			speed = velocity.magnitude;
 			m_currentDirection = speed > 0.01f ? velocity.normalized : Vector2.zero;
 		}
 		else
 		{
-			speed -= deceleration * Time.deltaTime;
+			speed -= deceleration * Time.fixedDeltaTime;
 			speed = Mathf.Max(speed, 0f);
 			velocity = m_currentDirection * speed;
 		}
@@ -127,14 +128,14 @@ public class SpinningTopController : MonoBehaviour
 		}
 		else
 		{
-			transform.rotation = Quaternion.Lerp(transform.rotation, defaultRotation, rotationReturnSpeed * Time.deltaTime);
+			transform.rotation = Quaternion.Lerp(transform.rotation, defaultRotation, rotationReturnSpeed * Time.fixedDeltaTime);
 		}
 	}
 
 	private void Move(Vector2 velocity)
 	{
 		// ���������̂ݎ蓮�ړ��i�W�����v��d�͂�Rigidbody�ɔC����j
-		Vector3 move = new Vector3(velocity.x, 0, velocity.y) * Time.deltaTime;
+		Vector3 move = new Vector3(velocity.x, 0, velocity.y) * Time.fixedDeltaTime;
 		rb.MovePosition(rb.position + move);
 
 		// Tilt in the direction of movement


### PR DESCRIPTION
#Summary
Changed the jump sound emitter to sound only when the player is jumping and not when he is pressing the jump button.
Swapped every Time.deltaTime with Time.fixedDeltaTime so the game movement is frame rate independent and stop having movement jittery.

#What changed
-- At the OnJump method, i added the if statement of the jumpsoundEmmiter into the statement that checks if the player is grounded and what context we have. So the sound dont go off everytime the jump keybind is pressed but need both context and isGrounded to be true so it can work. Otherwise the sound will emit no matter if we jump or not.
--In the FixedUpdate() method i swapped every Time.deltaTIme with Time.fixedDeltaTime. deltaTime doesnt work as intended inside the FixedUpdate() method, so we need to change it with the most appropriate for the situation being fixedDeltaTime.
